### PR TITLE
APIKIT-2518: Improve test coverage OData Extension

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven.surefire.plugin.version}</version>
                 <configuration>
-                    <argLine>-Dfile.encoding=UTF-8 -javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${session.executionRootDirectory}/target/jacoco.exec'</argLine>
+                    <argLine>-Dfile.encoding=UTF-8 -javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${session.executionRootDirectory}/target/jacoco.exec</argLine>
                     <systemPropertyVariables>
                         <!-- Just propagate this variable due to surefire will not do this when forked vm for tests -->
                         <mule.freePortFinder.lockPath>${java.io.tmpdir}/mule/freePortFinder</mule.freePortFinder.lockPath>


### PR DESCRIPTION
Removes a simple quote from jacoco args that were preventing it to gather correctly the coverage of the unit tests