### PR TITLE
W-12674099: Don't block the listener while waiting for a route

### DIFF
--- a/src/main/java/org/mule/module/apikit/odata/error/ODataErrorHandler.java
+++ b/src/main/java/org/mule/module/apikit/odata/error/ODataErrorHandler.java
@@ -33,10 +33,9 @@ public class ODataErrorHandler {
     return handle(event, ex, null);
   }
 
-  public static CoreEvent handle(CoreEvent event, Exception ex, List<Format> formats) {
-    Exception exceptionToBeThrown;
+  public static CoreEvent handle(CoreEvent event, Throwable ex, List<Format> formats) {
     Throwable cause = ExceptionUtils.getMessagingExceptionCause(ex);
-    exceptionToBeThrown = cause != null ? (Exception) cause : ex;
+    Throwable exceptionToBeThrown = cause != null ? cause : ex;
     if (exceptionToBeThrown instanceof MuleException) {
       // Exception thrown by APIkit
       exceptionToBeThrown = processMuleException((MuleException) exceptionToBeThrown);

--- a/src/main/java/org/mule/module/apikit/odata/processor/ODataApikitProcessor.java
+++ b/src/main/java/org/mule/module/apikit/odata/processor/ODataApikitProcessor.java
@@ -141,21 +141,19 @@ public class ODataApikitProcessor extends ODataRequestProcessor {
     return processEntityRequest(event, router, formats).flatMap((oDataPayload) -> {
       final List<Entry> entries = oDataPayload.getValue();
 
-      if (isEntityCount()) {
-        if (formats.contains(Format.Plain) || formats.contains(Format.Default)) {
-          String count = String.valueOf(entries.size());
-          return Mono.just(
-              new ODataPayload<>(oDataPayload.getMuleEvent(), count, oDataPayload.getStatus()));
-        } else {
-          return Mono
-              .error(new ODataUnsupportedMediaTypeException("Unsupported media type requested."));
-        }
-      } else {
+      if (!isEntityCount()) {
         oDataPayload.setFormatter(new ODataApiKitFormatter(getMetadataManager(), entity, oDataURL,
-            entries, oDataPayload.getInlineCount(getInlineCountParam(event))));
+                entries, oDataPayload.getInlineCount(getInlineCountParam(event))));
+        return Mono.just(oDataPayload);
       }
 
-      return Mono.just(oDataPayload);
+      if (formats.contains(Format.Plain) || formats.contains(Format.Default)) {
+        String count = String.valueOf(entries.size());
+        return Mono.just(
+            new ODataPayload<>(oDataPayload.getMuleEvent(), count, oDataPayload.getStatus()));
+      }
+
+      return Mono.error(new ODataUnsupportedMediaTypeException("Unsupported media type requested."));
     });
   }
 

--- a/src/main/java/org/mule/module/apikit/odata/processor/ODataApikitProcessor.java
+++ b/src/main/java/org/mule/module/apikit/odata/processor/ODataApikitProcessor.java
@@ -143,17 +143,18 @@ public class ODataApikitProcessor extends ODataRequestProcessor {
 
       if (!isEntityCount()) {
         oDataPayload.setFormatter(new ODataApiKitFormatter(getMetadataManager(), entity, oDataURL,
-                entries, oDataPayload.getInlineCount(getInlineCountParam(event))));
+            entries, oDataPayload.getInlineCount(getInlineCountParam(event))));
         return Mono.just(oDataPayload);
       }
 
       if (formats.contains(Format.Plain) || formats.contains(Format.Default)) {
         String count = String.valueOf(entries.size());
-        return Mono.just(
-            new ODataPayload<>(oDataPayload.getMuleEvent(), count, oDataPayload.getStatus()));
+        return Mono
+            .just(new ODataPayload<>(oDataPayload.getMuleEvent(), count, oDataPayload.getStatus()));
       }
 
-      return Mono.error(new ODataUnsupportedMediaTypeException("Unsupported media type requested."));
+      return Mono
+          .error(new ODataUnsupportedMediaTypeException("Unsupported media type requested."));
     });
   }
 

--- a/src/main/java/org/mule/module/apikit/odata/processor/ODataMetadataProcessor.java
+++ b/src/main/java/org/mule/module/apikit/odata/processor/ODataMetadataProcessor.java
@@ -13,6 +13,7 @@ import org.mule.module.apikit.odata.exception.ODataMethodNotAllowedException;
 import org.mule.module.apikit.odata.formatter.ODataPayloadFormatter.Format;
 import org.mule.module.apikit.odata.formatter.ODataPayloadMetadataFormatter;
 import org.mule.runtime.core.api.event.CoreEvent;
+import reactor.core.publisher.Mono;
 import java.util.List;
 
 public class ODataMetadataProcessor extends ODataRequestProcessor {
@@ -20,14 +21,14 @@ public class ODataMetadataProcessor extends ODataRequestProcessor {
     super(odataContext);
   }
 
-  public ODataPayload process(CoreEvent event, AbstractRouterInterface router, List<Format> formats)
-      throws Exception {
+  public Mono<ODataPayload<?>> process(CoreEvent event, AbstractRouterInterface router,
+      List<Format> formats) {
     if ("GET".equalsIgnoreCase(super.oDataContext.getMethod())) {
-      ODataPayload oDataPayload = new ODataPayload(event);
+      ODataPayload<?> oDataPayload = new ODataPayload<>(event);
       oDataPayload.setFormatter(new ODataPayloadMetadataFormatter(getMetadataManager()));
-      return oDataPayload;
+      return Mono.just(oDataPayload);
     } else {
-      throw new ODataMethodNotAllowedException("GET");
+      return Mono.error(new ODataMethodNotAllowedException("GET"));
     }
 
   }

--- a/src/main/java/org/mule/module/apikit/odata/processor/ODataRequestProcessor.java
+++ b/src/main/java/org/mule/module/apikit/odata/processor/ODataRequestProcessor.java
@@ -16,6 +16,7 @@ import org.mule.module.apikit.odata.context.OdataContext;
 import org.mule.module.apikit.odata.formatter.ODataPayloadFormatter.Format;
 import org.mule.module.apikit.odata.metadata.OdataMetadataManager;
 import org.mule.runtime.core.api.event.CoreEvent;
+import reactor.core.publisher.Mono;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -28,8 +29,8 @@ public abstract class ODataRequestProcessor {
     this.oDataContext = oDataContext;
   }
 
-  public abstract ODataPayload process(CoreEvent event, AbstractRouterInterface router,
-      List<Format> formats) throws Exception;
+  public abstract Mono<ODataPayload<?>> process(CoreEvent event, AbstractRouterInterface router,
+      List<Format> formats);
 
   protected OdataMetadataManager getMetadataManager() {
     return oDataContext.getOdataMetadataManager();

--- a/src/main/java/org/mule/module/apikit/odata/processor/ODataServiceDocumentProcessor.java
+++ b/src/main/java/org/mule/module/apikit/odata/processor/ODataServiceDocumentProcessor.java
@@ -14,6 +14,7 @@ import org.mule.module.apikit.odata.formatter.ODataPayloadFormatter.Format;
 import org.mule.module.apikit.odata.formatter.ServiceDocumentPayloadFormatter;
 import org.mule.module.apikit.odata.util.CoreEventUtils;
 import org.mule.runtime.core.api.event.CoreEvent;
+import reactor.core.publisher.Mono;
 import java.util.List;
 
 public class ODataServiceDocumentProcessor extends ODataRequestProcessor {
@@ -24,17 +25,17 @@ public class ODataServiceDocumentProcessor extends ODataRequestProcessor {
     super(odataContext);
   }
 
-  public ODataPayload process(CoreEvent event, AbstractRouterInterface router, List<Format> formats)
-      throws Exception {
+  public Mono<ODataPayload<?>> process(CoreEvent event, AbstractRouterInterface router,
+      List<Format> formats) {
     if ("GET".equalsIgnoreCase(super.oDataContext.getMethod())) {
 
       String url = getCompleteUrl(CoreEventUtils.getHttpRequestAttributes(event));
 
-      ODataPayload result = new ODataPayload(event);
+      ODataPayload<?> result = new ODataPayload<>(event);
       result.setFormatter(new ServiceDocumentPayloadFormatter(getMetadataManager(), url));
-      return result;
+      return Mono.just(result);
     } else {
-      throw new ODataMethodNotAllowedException("GET");
+      return Mono.error(new ODataMethodNotAllowedException("GET"));
     }
   }
 


### PR DESCRIPTION
This change refactors `ODataRequestProcessor.process` so it returns a `Mono<ODataPayload<?>>` instead of a bare `ODataPayload`. This change allows us to defer processing until the route is fulfilled (instead of blocking on the current thread 🤦).

The refactor is a bit ugly because it tries to keep the current behavior during exceptions as-is. **Please help me clean this up 😟.**

Finally, I didn't find a way to test this issue that wasn't ugly or resulted in tests that wasted a lot of time. Any help there will also be appreciated.