### PR TITLE
@W-16552229 - Update scope of plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,9 +206,11 @@
                         <exclude>**/*.xml</exclude>
                         <exclude>**/*.properties</exclude>
                         <exclude>**/*.md</exclude>
+                        <exclude>src/test/java/Fips*.java</exclude>
                     </excludes>
                     <includes>
-                        <include>**/*.java</include>
+                        <include>src/main/java/**/*.java</include>
+                        <include>src/test/java/**/*.java</include>
                     </includes>
                     <mapping>
                         <java>SLASHSTAR_STYLE</java>
@@ -236,6 +238,13 @@
                     <aggregator>false</aggregator>
                     <executionRoot>true</executionRoot>
                     <encoding>UTF-8</encoding>
+                    <includes>
+                        <include>src/main/java/**/*.java</include>
+                        <include>src/test/java/**/*.java</include>
+                    </includes>
+                    <excludes>
+                        <exclude>src/test/java/Fips*.java</exclude>
+                    </excludes>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
**Issue:**
The module was failing the FIPS pipeline because the following plugins were not limited to the current module's files. As a result, they were applied to all files, including those introduced by the FIPS pipeline. Since we don't have ownership over these external files, the license and format checks were failing on them:
- `com.mycila:license-maven-plugin`
- `com.marvinformatics.formatter:formatter-maven-plugin`

**Fix:**
The scope of these plugins has been restricted to include only the files within the module. FIPS-related files added during testing have been excluded to prevent unnecessary validation failures.